### PR TITLE
chore: drop stale .vscode/settings.json comment in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,7 +69,7 @@ env_test/
 *.env
 .env.*
 
-# Local development configs (but keep .vscode/settings.json)
+# Local development configs
 .editorconfig
 .tool-versions
 


### PR DESCRIPTION
One-line follow-up to the branch cleanup. The comment said "but keep .vscode/settings.json" — no longer true since PR #247 / #250 removed tracking. Aligns comment with actual behavior.